### PR TITLE
Memory reset assert, inferring BRAM, Timing for new WS2812B, and make clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,22 +3,25 @@ DEVICE = hx8k
 PROJ = ws2812
 PIN_DEF = 8k.pcf
 SHELL := /bin/bash # Use bash syntax
-BUILD_DIR = ./
+BUILD_DIR = ./build
 SRC_DIR = ./
 TEST_DIR = ./
 
-all: $(PROJ).bin $(PROJ).rpt 
+all: $(BUILD_DIR)/$(PROJ).bin $(BUILD_DIR)/$(PROJ).rpt formal
 
 MODULES = ws2812.v
 VERILOG = top.v $(MODULES)
-SRC = $(addprefix $(SRC_DIR)/, $(VERILOG))
+SRC = $(foreach ii,$(VERILOG),$(addprefix $(SRC_DIR)/, $(ii)))
 
 # $@ The file name of the target of the rule.rule
 # $< first pre requisite
 # $^ names of all preerquisites
 
+$(BUILD_DIR):
+	mkdir -p $(BUILD_DIR)
+
 # rules for building the blif file
-$(BUILD_DIR)/%.blif: $(SRC)
+$(BUILD_DIR)/%.blif: $(SRC) | $(BUILD_DIR)
 	yosys -p "synth_ice40 -top top -blif $@" $^ | tee $(BUILD_DIR)/build.log
 
 # asc
@@ -39,17 +42,16 @@ debug:
 	vvp ws2812.out -fst
 	gtkwave test.vcd gtk-ws2812.gtkw
 
-prog: $(PROJ).bin
+prog: $(BUILD_DIR)/$(PROJ).bin
 	iceprog $<
 
 formal:
 	sby -f $(PROJ).sby || gtkwave $(PROJ)/engine_0/*vcd hit_proc_formal.gtkw 
-
 
 clean:
 	rm -f $(BUILD_DIR)/*
 
 #secondary needed or make will remove useful intermediate files
 .SECONDARY:
-.PHONY: all prog clean 
+.PHONY: all prog clean formal debug
 

--- a/top.v
+++ b/top.v
@@ -6,18 +6,35 @@ module top (
     output ws_data
 );
 
+    localparam NUM_LEDS = 100;
+
     reg reset = 1;
     always @(posedge clk)
         reset <= 0;
 
-    reg [23:0] count = 0;
-    always @(posedge clk)
+    reg [14:0] count = 0;
+    reg [1:0]  color_ind = 0;
+    always @(posedge clk) begin
         count <= count + 1;
+        if (&count) begin
+            if (led_num == NUM_LEDS) begin
+                led_num <= 0;
+                color_ind <= color_ind + 1;
+                case (color_ind)
+                  2'b00 : led_rgb_data <= 24'h10_00_00;
+                  2'b01 : led_rgb_data <= 24'h00_10_00;
+                  2'b10 : led_rgb_data <= 24'h00_00_10;
+                  2'b11 : led_rgb_data <= 24'h10_10_10;
+		endcase
+            end else
+               led_num <= led_num + 1;
+	end
+    end
 
     reg [23:0] led_rgb_data = 24'h00_00_10;
     reg [7:0] led_num = 0;
     wire led_write = &count;
 
-    ws2812 #(.NUM_LEDS(4)) ws2812_inst(.data(ws_data), .clk(clk), .reset(reset), .rgb_data(led_rgb_data), .led_num(led_num), .write(led_write));
+    ws2812 #(.NUM_LEDS(NUM_LEDS)) ws2812_inst(.data(ws_data), .clk(clk), .reset(reset), .rgb_data(led_rgb_data), .led_num(led_num), .write(led_write));
 
 endmodule

--- a/ws2812.v
+++ b/ws2812.v
@@ -129,6 +129,7 @@ module ws2812 (
                 if ($past(reset)) begin
                     assert(bit_counter == t_reset);
                     assert(rgb_counter == 23);
+                    assert(led_reg[$past(led_num)] == 0);
                 end
 
         always @(posedge clk) begin

--- a/ws2812.v
+++ b/ws2812.v
@@ -51,19 +51,27 @@ module ws2812 (
 
     reg [1:0] state = STATE_RESET;
 
+    reg [23:0] led_color;
+
     // handle reading new led data
-    always @(posedge clk)
+    always @(posedge clk) begin
         if(write)
             led_reg[led_num] <= rgb_data;
-
+        led_color <= led_reg[led_counter];
+    end
     integer i;
 
     always @(posedge clk)
         // reset
         if(reset) begin
             // initialise led data to 0
+	    // comment out to infer BRAM, but required to pass formal
+            `ifdef `INFER_BRAM
+	    $display("Bypassing memory reset to allow BRAM");
+	    `else
             for (i=0; i<NUM_LEDS; i=i+1)
                 led_reg[i] <= 0;
+	    `endif
 
             state <= STATE_RESET;
             bit_counter <= t_reset;
@@ -90,7 +98,7 @@ module ws2812 (
 
             STATE_DATA: begin
                 // output the data
-                if(led_reg[led_counter][rgb_counter])
+                if(led_color[rgb_counter])
                     data <= bit_counter > (t_period - t_on);
                 else
                     data <= bit_counter > (t_period - t_off);

--- a/ws2812.v
+++ b/ws2812.v
@@ -1,4 +1,7 @@
 `default_nettype none
+
+//`define NO_MEM_RESET 1
+
 module ws2812 (
     input [23:0] rgb_data,
     input [7:0] led_num,
@@ -59,16 +62,19 @@ module ws2812 (
             led_reg[led_num] <= rgb_data;
         led_color <= led_reg[led_counter];
     end
+
     integer i;
 
     always @(posedge clk)
         // reset
         if(reset) begin
-            // initialise led data to 0
-	    // comment out to infer BRAM, but required to pass formal
-            `ifdef `INFER_BRAM
+	    //  In order to infer BRAM, can't have a reset condition
+	    //  like this. But it will fail formal if you don't reset
+	    //  it.
+            `ifdef NO_MEM_RESET
 	    $display("Bypassing memory reset to allow BRAM");
 	    `else
+            // initialise led data to 0
             for (i=0; i<NUM_LEDS; i=i+1)
                 led_reg[i] <= 0;
 	    `endif


### PR DESCRIPTION
Using the code to drive a longer strand or WS2812B I had a few issues.
* `make clean` removed everything by default
* newer WS2812B require a longer reset signal duration
* I noticed asserts didn't cover resetting the memory
* When using a longer strand and more complex color logic, I couldn't route